### PR TITLE
Add support for signing/checking different kinds of request object.

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,6 +1,11 @@
 PENDING
 =======
 
+ * Allow the main API functions to accept a WebOb Request object, a
+   requests Request object, or a WSGI environ dict as first argument.
+   This should make it easier to implement client programs.
+ * macauthlib.sign_request() now returns the Authorization header value, which
+   is useful if you pass it something immutable as the request to be signed.
  * Hide functions from macauthlib.utils that were previously available
    directly from macauthlib.  This will ensure users import them from the
    canonical location.

--- a/README.rst
+++ b/README.rst
@@ -8,7 +8,7 @@ simple HTTP request-signing scheme described in:
     http://tools.ietf.org/html/draft-ietf-oauth-v2-http-mac-01
 
 To access resources using MAC Access Authentication, the client must have
-obtained a set of MAC credentials including an id and secret key.  They use
+obtained a set of MAC credentials including an id and a secret key.  They use
 these credentials to make signed requests to the server.
 
 When accessing a protected resource, the server will generate a 401 challenge
@@ -41,13 +41,58 @@ an authentication scheme.  For MAC Auth clients, it provides the following
 function:
 
     * sign_request(req, id, key, hashmod=sha1):  sign a request using
-                                                 MAC Access Auth.
+      MAC Access Auth.
 
 For MAC Auth servers, it provides the following functions:
 
-    * get_id(req):  get the claimed MAC Auth id
-                    from the request.
+    * get_id(req):  get the claimed MAC Auth id from the request.
 
     * check_signature(req, key, hashmod=sha1):  check that the request was
-                                                signed with the given key.
+      signed with the given key.
 
+The request objects passed to these functions can be any of a variety of
+common object types:
+
+    * a WSGI environment dict
+    * a webob.Request object
+    * a requests.Request object
+    * a string or file-like object of request data
+
+A typical use for a client program might be to install the sign_request
+function as an authentication hook when using the requests library, like this::
+
+    import requests
+    import functools
+    import macauthlib
+
+    # Hook up sign_request() to be called on every request.
+    auth_hook = functools.partial(macuathlib.sign_request, id="XXX", key="YYY")
+    session = requests.session(hooks={"pre_request": auth_hook})
+
+    # Then use the session as normal, and the auth is applied transparently.
+    session.get("http://www.secret-data.com/get-my-data")
+
+
+A typical use for a server program might be to verify requests using a WSGI
+middleware component, like this::
+
+    class MACAuthMiddleware(object):
+
+        # ...setup code goes here...
+
+        def __call__(self, environ, start_response):
+
+            # Find the identity claimed by the request.
+            id = macauthlib.get_id(environ)
+
+            # Look up their secret key.
+            key = self.SECRET_KEYS[id]
+
+            # If the signature is invalid, error out.
+            if not macauthlib.check_signature(environ, key):
+                start_response("401 Unauthorized",
+                               [("WWW-Authenticate", "MAC")])
+                return [""]
+
+            # Otherwise continue to the main application.
+            return self.application(environ, start_response)

--- a/macauthlib/tests/test_request_objects.py
+++ b/macauthlib/tests/test_request_objects.py
@@ -1,0 +1,112 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this file,
+# You can obtain one at http://mozilla.org/MPL/2.0/.
+
+import unittest
+import StringIO
+
+import webob
+import requests
+
+from macauthlib import sign_request, check_signature
+
+# These parameters define a known-good signature for a specific request.
+# We test a bunch of different ways to input that request into the lib
+# and check whether they all agree on the signature.
+
+TEST_REQ = "POST /resource/1?b=1&a=2 HTTP/1.1\r\n"\
+           "Host: example.com\r\n"\
+           "Content-Length: 11\r\n"\
+           "\r\n"\
+           "hello world"
+
+TEST_REQ_SIGNED = "POST /resource/1?b=1&a=2 HTTP/1.1\r\n"\
+                  "Host: example.com\r\n"\
+                  "Content-Length: 11\r\n"\
+                  "Authorization: MAC nonce=\"dj83hs9s\","\
+                  "                   mac=\"SIBz/j9mI1Ba2Y+10wdwbQGv2Yk=\","\
+                  "                   id=\"h480djs93hd8\","\
+                  "                   ts=\"1336363200\"\r\n"\
+                  "\r\n"\
+                  "hello world"
+
+TEST_PARAMS = {
+    "id": "h480djs93hd8",
+    "ts": "1336363200",
+    "nonce": "dj83hs9s"
+}
+
+TEST_ID = "h480djs93hd8"
+
+TEST_KEY = "489dks293j39"
+
+TEST_SIG = "SIBz/j9mI1Ba2Y+10wdwbQGv2Yk="
+
+
+class TestRequestObjects(unittest.TestCase):
+
+    def test_passing_webob_request_as_request_object(self):
+        req = webob.Request.from_bytes(TEST_REQ)
+        assert not check_signature(req, TEST_KEY, nonces=False)
+        authz = sign_request(req, TEST_ID, TEST_KEY, params=TEST_PARAMS)
+        assert TEST_SIG in authz
+        assert check_signature(req, TEST_KEY, nonces=False)
+
+    def test_passing_environ_dict_as_request_object(self):
+        req = {
+            "wsgi.url_scheme": "http",
+            "REQUEST_METHOD": "POST",
+            "HTTP_HOST": "example.com",
+            "HTTP_CONTENT_LENGTH": "11",
+            "PATH_INFO": "/resource/1",
+            "QUERY_STRING": "b=1&a=2",
+            "wsgi.input": StringIO.StringIO("hello world")
+        }
+        assert not check_signature(req, TEST_KEY, nonces=False)
+        authz = sign_request(req, TEST_ID, TEST_KEY, params=TEST_PARAMS)
+        assert TEST_SIG in authz
+        assert check_signature(req, TEST_KEY, nonces=False)
+
+    def test_passing_bytestring_as_request_object(self):
+        assert not check_signature(TEST_REQ, TEST_KEY, nonces=False)
+        authz = sign_request(TEST_REQ, TEST_ID, TEST_KEY, params=TEST_PARAMS)
+        assert TEST_SIG in authz
+        assert check_signature(TEST_REQ_SIGNED, TEST_KEY, nonces=False)
+
+    def test_passing_filelike_as_request_object(self):
+        req = StringIO.StringIO(TEST_REQ)
+        assert not check_signature(req, TEST_KEY, nonces=False)
+        req = StringIO.StringIO(TEST_REQ)
+        authz = sign_request(req, TEST_ID, TEST_KEY, params=TEST_PARAMS)
+        assert TEST_SIG in authz
+        req = StringIO.StringIO(TEST_REQ_SIGNED)
+        assert check_signature(req, TEST_KEY, nonces=False)
+
+    def test_passing_requests_request_as_request_object(self):
+        req = requests.Request(
+            url="http://example.com/resource/1",
+            method="POST",
+            params=[("b", "1"), ("a", "2")],
+            data="hello world",
+        )
+        assert not check_signature(req, TEST_KEY, nonces=False)
+        authz = sign_request(req, TEST_ID, TEST_KEY, params=TEST_PARAMS)
+        assert TEST_SIG in authz
+        assert check_signature(req, TEST_KEY, nonces=False)
+
+    def test_using_sign_request_as_a_requests_auth_hook(self):
+        # We don't actually want to perform the request, so
+        # we have the hook error out once it has run and we
+        # catch-and-ignore that error.
+        def pre_request_hook(req):
+            sign_request(req, TEST_ID, TEST_KEY)
+            assert check_signature(req, TEST_KEY, nonces=False)
+            raise RuntimeError("aborting the request")
+
+        session = requests.session(hooks={"pre_request": pre_request_hook})
+        try:
+            session.post("http://example.com/resource/1",
+                         params=[("b", "1"), ("a", "2")],
+                         data="hello world")
+        except RuntimeError, e:
+            assert "aborting the request" in str(e)

--- a/setup.py
+++ b/setup.py
@@ -12,6 +12,8 @@ with open(os.path.join(here, 'CHANGES.txt')) as f:
 
 requires = ['webob']
 
+tests_requires = requires + ['requests']
+
 setup(name='macauthlib',
       version='0.3.0',
       description='macauth',


### PR DESCRIPTION
The library still uses webob internally, but the high-level API
functions can now accept either a webob Request, a requests Request
or a plain WSGI environ dict.  This makes it easier to integrate in
a variety of client code.

@tarekziade what do you think?
